### PR TITLE
Revert "ido: Allow getdents64 syscall for mediacodec"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -174,9 +174,6 @@ TARGET_RIL_VARIANT := caf
 include device/qcom/sepolicy/sepolicy.mk
 BOARD_SEPOLICY_DIRS += $(LOCAL_PATH)/sepolicy
 
-# Seccomp
-BOARD_SECCOMP_POLICY += $(LOCAL_PATH)/seccomp
-
 # Video
 TARGET_HAVE_SIGNED_VENUS_FW := true
 

--- a/seccomp/mediacodec-seccomp.policy
+++ b/seccomp/mediacodec-seccomp.policy
@@ -1,3 +1,0 @@
-# device specific syscalls
-# extension of services/mediacodec/minijail/seccomp_policy/mediacodec-seccomp-arm.policy
-getdents64: 1


### PR DESCRIPTION
This reverts commit d04538c838e89b9bb32918bf448e9ca1f67224b5.

* This is now allowed globally

Change-Id: Icc6e7ed10290d4957474c4b1859bd8548bca4f04