### PR TITLE
ido: Import build fingerprint from V8.1.3.0.LAIMIDI

### DIFF
--- a/lineage.mk
+++ b/lineage.mk
@@ -24,3 +24,8 @@ PRODUCT_NAME := lineage_ido
 BOARD_VENDOR := Xiaomi
 
 PRODUCT_GMS_CLIENTID_BASE := android-xiaomi
+
+# Build fingerprint
+PRODUCT_BUILD_PROP_OVERRIDES += \
+    BUILD_FINGERPRINT="Xiaomi/ido/ido:5.1.1/LMY47V/V8.1.3.0.LAIMIDI:user/release-keys" \
+    PRIVATE_BUILD_DESC="ido-user 5.1.1 LMY47V V8.1.3.0.LAIMIDI release-keys"


### PR DESCRIPTION
* Xiaomi/ido/ido:5.1.1/LMY47V/V8.1.3.0.LAIMIDI:user/release-keys
* Not using latest firmware's fingerprint since it fails SafetyNet CTS check.

Change-Id: I601c750651cc3845f70bb49a15dcffa8d22ef67e
Signed-off-by: Albert I <krascgq@outlook.co.id>